### PR TITLE
feat: adopt agent-sandbox control plane for tenant workspaces (runc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,11 @@ jobs:
           echo "::endgroup::"
 
       - name: Helm lint
-        run: helm lint helm/charts/openclaw-platform/ --set ingress.enabled=true --set ingress.host=test.example.com --set tenant.name=test
+        run: |
+          # legacy (Deployment) mode
+          helm lint helm/charts/openclaw-platform/ --set ingress.enabled=true --set ingress.host=test.example.com --set tenant.name=test
+          # sandbox (SandboxClaim/SandboxTemplate) mode
+          helm lint helm/charts/openclaw-platform/ --set ingress.enabled=true --set ingress.host=test.example.com --set tenant.name=test --set sandbox.enabled=true
 
       - name: CDK unit tests
         working-directory: cdk

--- a/docs/adr/0001-adopt-agent-sandbox-model.md
+++ b/docs/adr/0001-adopt-agent-sandbox-model.md
@@ -1,0 +1,85 @@
+# ADR-0001: Adopt the agent-sandbox model for tenant workspace isolation
+
+- **Status:** Accepted
+- **Date:** 2026-06-18
+- **Deciders:** HC Lo (hclo)
+- **Tracking issue:** [#365](https://github.com/snese/sample-openclaw-multi-tenant-platform/issues/365)
+
+## Context
+
+Today each tenant workspace is a plain Kubernetes `Deployment`, isolated only
+at the namespace and `NetworkPolicy` level. Model-generated and user-driven
+code inside an OpenClaw workspace therefore runs against the full host-kernel
+syscall surface. For a multi-tenant platform that executes semi-trusted,
+LLM-driven workloads, this is the weakest part of the current design.
+
+We also lack a first-class primitive for the thing each tenant actually is: a
+**long-running, stateful, singleton workspace with a stable identity and
+persistent storage**. Modelling that as a `Deployment` (stateless, replicated)
+is a poor fit and forces us to hand-stitch Service, PVC, and scaling behaviour.
+
+We want:
+
+1. A kernel-level isolation tier we can turn on per workload.
+2. A declarative, lifecycle-managed singleton primitive that matches the
+   per-tenant persistent workspace model.
+3. To stay AWS-native and avoid adding a heavy, non-AWS supply-chain dependency.
+
+## Decision
+
+Adopt the [kubernetes-sigs/agent-sandbox](https://agent-sandbox.sigs.k8s.io/)
+model — the `Sandbox` CRD plus the `SandboxTemplate` / `SandboxClaim` /
+`SandboxWarmPool` extensions — as packaged by
+[awslabs/ai-on-eks](https://awslabs.github.io/ai-on-eks/docs/infra/agents/agent-sandbox).
+
+The runtime is intentionally pluggable: this ADR commits only to the **model**.
+The kernel-isolation tier (gVisor) is delivered later as a `SandboxTemplate`
+`runtimeClassName` field, not as a separate layer (see ADR-0005).
+
+## Options considered
+
+### A. Status quo — namespace + NetworkPolicy only
+Rejected. Provides no kernel isolation; model-generated code keeps the full
+host syscall surface. Does not address the stateful-singleton modelling gap.
+
+### B. NVIDIA OpenShell / NemoClaw
+Rejected. It is alpha and host-centric (a single-machine, always-on agent
+hardening CLI), and would have to be adapted into a sidecar/DaemonSet to fit a
+multi-tenant cluster. Its headline value — inference-layer credential injection
+so the agent never sees the API key — is **already provided** in this sample by
+Amazon Bedrock + EKS Pod Identity (zero API keys), so the marginal benefit here
+is effectively zero. Adopting it would also dilute the sample's "all
+AWS-native" positioning and add NVIDIA supply-chain and support risk.
+
+### C. kubernetes-sigs agent-sandbox (chosen)
+Kubernetes-native CRDs purpose-built for isolated, stateful, singleton
+workloads in multi-tenant clusters. Integrates cleanly with the existing stack
+(Karpenter, ArgoCD ApplicationSet, Pod Identity/IRSA, NetworkPolicy, ResourceQuota).
+gVisor and Kata are selectable per template rather than bespoke runtime layers.
+Maintained by a Kubernetes SIG and packaged for EKS by awslabs/ai-on-eks.
+
+## Consequences
+
+**Positive**
+- A declarative "singleton pod with stable identity + persistent storage"
+  primitive that matches the per-tenant workspace model directly.
+- Kernel isolation (gVisor) becomes a one-field change on a template (ADR-0005).
+- Stays AWS-native + OSS SIG; no NVIDIA wrapper in the supply chain.
+
+**Negative / costs**
+- New control-plane dependency: the agent-sandbox controller + CRDs must be
+  installed and operated (install script already added in PR #365).
+- The API is still evolving; we must pin a version and track drift
+  (see ADR-0002).
+- The routing and scale-to-zero model must change, because a `Sandbox` is a
+  singleton with no `/scale` subresource and the wake/hibernation path differs
+  from the current KEDA HTTP add-on (see ADR-0004).
+- Per-tenant identity (ServiceAccount), secrets, and storage must be expressed
+  within the template/claim model rather than a hand-written Deployment
+  (see ADR-0003).
+
+## References
+
+- [Agent Sandbox documentation](https://agent-sandbox.sigs.k8s.io/docs/)
+- [awslabs/ai-on-eks — Agent Sandbox on EKS](https://awslabs.github.io/ai-on-eks/docs/infra/agents/agent-sandbox)
+- [docs/agent-sandbox.md](../agent-sandbox.md) — original design note (superseded in part by this ADR set)

--- a/docs/adr/0002-pin-agent-sandbox-v0.4.5.md
+++ b/docs/adr/0002-pin-agent-sandbox-v0.4.5.md
@@ -1,0 +1,68 @@
+# ADR-0002: Pin agent-sandbox v0.4.5 (`v1alpha1`) and use the direct `sandboxTemplateRef` chain
+
+- **Status:** Proposed
+- **Date:** 2026-06-18
+- **Deciders:** HC Lo (hclo)
+- **Depends on:** [ADR-0001](0001-adopt-agent-sandbox-model.md)
+
+## Context
+
+The agent-sandbox API is still evolving and the resource shape changed between
+releases. The install script (`scripts/setup-agent-sandbox.sh`) pins
+`AGENT_SANDBOX_VERSION=v0.4.5`, and the runc `SandboxTemplate` was validated
+against CRD `v0.4.5`.
+
+We verified the actual v0.4.5 CRD by pulling
+`releases/download/v0.4.5/extensions.yaml` directly. Findings:
+
+- v0.4.5 serves **`extensions.agents.x-k8s.io/v1alpha1`**.
+- `SandboxClaim.spec` **requires `sandboxTemplateRef`** (a `{name}` reference
+  **directly** to a `SandboxTemplate`). It also has an optional `warmpool`
+  string (default `"default"`), `lifecycle`, `env`, and `additionalPodMetadata`.
+
+The **current upstream docs** describe a later API (`v1beta1`) in which
+`SandboxClaim.spec` drops `sandboxTemplateRef` and instead requires
+`warmPoolRef` pointing at a `SandboxWarmPool`. That is a different chain
+(`SandboxClaim → SandboxWarmPool → SandboxTemplate`) and would not validate
+against the v0.4.5 CRD we install.
+
+> An earlier draft of this design incorrectly assumed the `v1beta1`
+> (`warmPoolRef`) shape was authoritative. It is not, for the version we pin.
+> This ADR records the verified v0.4.5 behaviour.
+
+## Decision
+
+Pin the controller and CRDs to **v0.4.5 (`v1alpha1`)** for this PR series, and
+use the **direct `SandboxClaim.spec.sandboxTemplateRef → SandboxTemplate`**
+chain. Do not author `v1beta1`/`warmPoolRef` manifests against the v0.4.5
+install. Treat the migration to `v1beta1` (warmPoolRef and any related renames)
+as a separate, future ADR taken when we deliberately bump the controller.
+
+## Options considered
+
+- **Pin v0.4.5 (chosen):** reproducible, matches the validated CRD, direct
+  chain needs no WarmPool for the cold-start path.
+- **Track `latest`:** rejected — the `v1alpha1 → v1beta1` claim-schema change
+  would break tenant manifests at deploy time on the next upstream release.
+- **Author `v1beta1` now:** rejected — the installed CRD is v0.4.5; v1beta1
+  manifests would be rejected by the API server.
+
+## Consequences
+
+**Positive**
+- Manifests validate against the exact installed CRD; deploys are reproducible.
+- The direct chain is simpler — no `SandboxWarmPool` object required on the
+  cold-start path.
+
+**Negative / open items**
+- We are pinned to an older API and must write a migration ADR before adopting
+  newer controller features that only exist in `v1beta1`.
+- The v0.4.5 `warmpool` field defaults to `"default"`. **Open item:** confirm a
+  `SandboxClaim` cold-starts with no pre-existing `SandboxWarmPool` named
+  `default`, versus needing to create one. To be verified during PR #1 deploy
+  verification (profile `hclo-mac`, `us-east-1`).
+
+## References
+
+- v0.4.5 CRD: `https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.4.5/extensions.yaml`
+- Current API reference (`v1beta1`, for contrast): https://agent-sandbox.sigs.k8s.io/docs/api/

--- a/docs/adr/0003-per-tenant-sandboxtemplate.md
+++ b/docs/adr/0003-per-tenant-sandboxtemplate.md
@@ -1,0 +1,78 @@
+# ADR-0003: Render a per-tenant SandboxTemplate to carry ServiceAccount, Secret, PVC, and env
+
+- **Status:** Proposed
+- **Date:** 2026-06-18
+- **Deciders:** HC Lo (hclo)
+- **Depends on:** [ADR-0002](0002-pin-agent-sandbox-v0.4.5.md)
+
+## Context
+
+Each tenant's OpenClaw workspace pod needs several **per-tenant, reference-typed**
+inputs that the current `Deployment` expresses today:
+
+- a per-tenant **ServiceAccount** for EKS Pod Identity (zero-API-key Bedrock);
+- the gateway-token **Secret** `{fullname}-gateway-token` (today via `envFrom.secretRef`);
+- **`TENANT_NAMESPACE`** from the downward API (`fieldRef`);
+- a per-tenant data **PVC**;
+- three initContainers (config, skills, tools — including the IMDS
+  `169.254.170.23` Pod Identity patch).
+
+In the pinned v0.4.5 API (ADR-0002), `SandboxClaim.spec.env` is a list of plain
+`{name, value}` pairs — it has **no `valueFrom`**, so it cannot inject a Secret,
+a downward-API value, or a ServiceAccount. Those constructs only exist inside a
+**PodSpec**. The `SandboxTemplate.spec.podTemplate` *is* a full PodSpec and can
+express all of them — but a single shared template cannot carry per-tenant
+*names* (SA name, secret name, PVC).
+
+The platform already renders per-tenant output through the ArgoCD
+`ApplicationSet` + Helm chart, so per-tenant rendering is a path we already own.
+
+## Decision
+
+Render a **per-tenant `SandboxTemplate`** through the existing ApplicationSet /
+Helm path (one template per tenant, named for the tenant). The template's
+`podTemplate` carries the per-tenant `serviceAccountName`, secret references,
+downward-API env, volumes, initContainers, and a `volumeClaimTemplates` entry
+for the data PVC. Each tenant's `SandboxClaim` references its own template by
+name.
+
+Set **`envVarsInjectionPolicy: Allowed`** on the template (the v0.4.5 default is
+`Disallowed`) so that any future claim-level plain env is still accepted.
+
+Consequently we do **not** keep "one shared template per runtime tier". The
+runtime tier (runc/gVisor) is selected by a field *within* each per-tenant
+template, driven by a Helm value (consistent with ADR-0005).
+
+## Options considered
+
+- **A. Per-tenant SandboxTemplate (chosen):** fits the existing per-tenant Helm
+  rendering; carries SA/Secret/PVC/env via a real PodSpec.
+- **B. Single shared template + `claim.env`:** rejected — `claim.env` is plain
+  `name/value` only; cannot inject the gateway-token Secret, the downward-API
+  namespace, or a per-tenant ServiceAccount.
+- **C. One template per tier + controller naming-convention magic:** rejected —
+  relies on undocumented controller behaviour for per-tenant SA/secret binding;
+  high risk.
+
+## Consequences
+
+**Positive**
+- Per-tenant SA (Pod Identity), Secret, PVC, and env are all expressible.
+- Reuses the existing ApplicationSet render-per-tenant mechanism; little new
+  machinery.
+
+**Negative / open items**
+- More `SandboxTemplate` objects (one per tenant) instead of one per tier.
+  Acceptable at this sample's tenant scale; revisit for very large fleets
+  (a pool model is the large-scale variant).
+- The gVisor tier (ADR-0005) becomes a Helm value flipping `runtimeClassName`
+  in the per-tenant template, rather than a second shared template.
+- agent-sandbox's secure default sets `automountServiceAccountToken: false`.
+  **Open item:** confirm Pod Identity still works (it relies on the Pod Identity
+  Agent + webhook, not the SA token mount). Verify during PR #1 deploy
+  verification.
+
+## References
+
+- v0.4.5 `SandboxClaim` / `SandboxTemplate` schema — see [ADR-0002](0002-pin-agent-sandbox-v0.4.5.md)
+- [docs/agent-sandbox.md](../agent-sandbox.md)

--- a/docs/adr/0004-defer-hibernation-and-router.md
+++ b/docs/adr/0004-defer-hibernation-and-router.md
@@ -1,0 +1,117 @@
+# ADR-0004: Defer hibernation + sandbox-router; PR #1 keeps path-based routing and `operatingMode: Running`
+
+- **Status:** Proposed
+- **Date:** 2026-06-18
+- **Deciders:** HC Lo (hclo)
+- **Depends on:** [ADR-0001](0001-adopt-agent-sandbox-model.md), [ADR-0003](0003-per-tenant-sandboxtemplate.md)
+
+## Context
+
+Today scale-to-zero is provided by the **KEDA HTTP add-on**: a per-tenant
+`HTTPScaledObject` targets the tenant `Deployment`, scales it 0↔1 on request
+rate (idle 900s), and its interceptor holds an inbound request while a
+scaled-to-zero tenant starts. Routing is **path-based**:
+`claw.example.com/t/<tenant>/` via a Gateway API `HTTPRoute`.
+
+Adopting the Sandbox model (ADR-0001) removes the `Deployment`. A `Sandbox` is a
+singleton with no `/scale` subresource, so KEDA HTTP can no longer target it.
+The agent-sandbox model offers its own scale-to-zero via **hibernation**
+(pause on idle, "automatic resume on incoming network connections") and a
+**sandbox-router** for scalable access. We researched both before committing.
+
+Verified findings that change the picture:
+
+1. **sandbox-router is header-based, not path-based.** It routes by an
+   `X-Sandbox-ID` (+ namespace/port) HTTP header to
+   `<id>.<ns>.svc.cluster.local`. Our contract is path-based (`/t/<tenant>/`),
+   sent by browsers/auth-ui. Stock Gateway API cannot easily translate a
+   dynamic path segment into a header, so adopting the router changes the
+   routing/UX contract — it is not a drop-in addition.
+2. **The router does not itself wake a hibernated sandbox.** Its own tests
+   assert that an unreachable sandbox returns **502 Bad Gateway**. So the router
+   is a reverse proxy, not an activator.
+3. **The wake/hibernation mechanism is unverified.** We could not find a doc
+   that states whether hibernation *pauses* the pod (endpoint stays, connection
+   can trigger resume) or *deletes* it (then who triggers resume?). The
+   controller flags we found are concurrency-only; there is **no idle-timeout
+   knob**, and `shutdownTime` is a delete-TTL, not idle-hibernate. The cost
+   story (scale-to-zero) hinges entirely on this unknown.
+
+## Decision
+
+Split the scale-to-zero redesign out of PR #1.
+
+**PR #1** runs each tenant Sandbox with **`operatingMode: Running`** (always-on,
+no hibernation). Routing stays **path-based**: the per-tenant `HTTPRoute`
+backend is repointed from the old Deployment Service to the **Sandbox's
+controller-created headless Service**. The KEDA `HTTPScaledObject` is **removed**
+in PR #1 (it targeted a Deployment that no longer exists and cannot target a
+Sandbox); we accept an always-on interim cost posture.
+
+**The sandbox-router, hibernation, and the scale-to-zero replacement are
+deferred to PR #1.5**, gated on first resolving (a) the wake mechanism
+(pause-vs-delete and what triggers resume — to be answered by reading the
+controller source or by empirical test on the verification cluster) and (b) the
+path→header routing strategy. Each will be captured in its own ADR.
+
+## Options considered
+
+- **A. PR #1 keeps path routing + `Running`; defer router/hibernation (chosen):**
+  isolates the verified, low-risk lifecycle adoption from the unresolved
+  scale-to-zero redesign; PR #1 is deploy-verifiable now.
+- **B. Adopt sandbox-router + hibernation in PR #1:** rejected — wake mechanism
+  unverified, router is header-based vs our path-based, router returns 502 not
+  wake; high risk of shipping a broken scale-to-zero.
+- **C. Drop scale-to-zero permanently:** rejected — the cost story is a stated
+  value of the sample. We defer, we do not abandon it.
+
+## Consequences
+
+**Positive**
+- PR #1 is shippable and deploy-verifiable without the unresolved hibernation
+  question.
+- Routing and UX contract are unchanged for PR #1.
+
+**Negative / interim**
+- Tenants run **always-on** in PR #1 → higher idle cost until PR #1.5. If useful,
+  a `shutdownTime`/TTL can still bound truly-abandoned workspaces.
+- The original framing "hibernation replaces KEDA scale-to-zero" is **not yet
+  proven**; PR #1.5 must validate it end-to-end before we claim the cost benefit.
+
+## Resolution (2026-06-18, verified from controller source @ tag v0.4.5)
+
+The pause-vs-delete question is settled by reading
+`controllers/sandbox_controller.go` at the v0.4.5 tag:
+
+- v0.4.5 (`v1alpha1`) uses `Sandbox.Spec.Replicas` (0/1); there is **no**
+  `operatingMode: Suspended` (that is a later `v1beta1` field).
+- When `Replicas == 0` the controller **deletes the pod**
+  (`"Deleting Pod because .Spec.Replicas is 0"` → `r.Delete(ctx, pod)`), so the
+  Service endpoint disappears. **This is Case B (delete), not pause.**
+- There is **no connection-triggered resume** anywhere in the v0.4.5 core or
+  SandboxClaim controllers. The "automatic resume on incoming network
+  connections" described in the current docs is a later (`v1beta1`) capability,
+  not present in v0.4.5.
+
+**Consequence for KEDA:** on v0.4.5, the Sandbox model does **not** replace
+KEDA's scale-to-zero at all — it provides isolation + lifecycle + identity only.
+Scale-to-zero with wake still requires both an idle scaler and an activator
+(KEDA's two roles). The sandbox-router does not wake (returns 502).
+
+**Therefore PR #1 ships always-on (`Replicas=1`, KEDA removed), and the
+scale-to-zero path forks into three options for a later decision:**
+
+1. **No scale-to-zero** — accept always-on (simplest).
+2. **Custom activator on v0.4.5** — a path-native component that patches
+   `Sandbox.Spec.Replicas` 0↔1 on idle/request (we own and maintain it).
+3. **Migrate to v1beta1** — gain native hibernation + wake-on-connection, but
+   the claim schema changes to `warmPoolRef` (re-do ADR-0002/0003); larger
+   migration.
+
+This decision is deferred to its own ADR; it does not block PR #1.
+
+## References
+
+- Sandbox Router README: `https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/README.md`
+- Controller configuration flags: `https://github.com/kubernetes-sigs/agent-sandbox/blob/main/docs/configuration.md`
+- [docs/agent-sandbox.md](../agent-sandbox.md) — original KEDA→hibernation framing (revised by this ADR)

--- a/docs/adr/0005-phased-delivery.md
+++ b/docs/adr/0005-phased-delivery.md
@@ -1,0 +1,74 @@
+# ADR-0005: Phased delivery — lifecycle → router/hibernation → gVisor
+
+- **Status:** Proposed
+- **Date:** 2026-06-18
+- **Deciders:** HC Lo (hclo)
+- **Depends on:** [ADR-0001](0001-adopt-agent-sandbox-model.md), [ADR-0003](0003-per-tenant-sandboxtemplate.md), [ADR-0004](0004-defer-hibernation-and-router.md)
+
+## Context
+
+Adopting agent-sandbox touches three independent risk surfaces: the
+**lifecycle model** (Deployment → Sandbox), the **scale-to-zero data path**
+(KEDA → router + hibernation), and the **runtime/isolation tier** (runc →
+gVisor, which needs new node infrastructure). Bundling them into one change
+makes review and deploy-verification hard and couples unrelated risks.
+
+Each PR must be validated by a **real deployment** (profile `hclo-mac`,
+`us-east-1`) before it is promoted: verify on the `snese` repo first, then open
+the PR to `aws-samples` and sync the `gitlab` remote.
+
+## Decision
+
+Deliver in three phases, each independently deploy-verifiable.
+
+### PR #1 — Sandbox lifecycle adoption (runc)
+- Install controller + CRDs (done) and a per-tenant `SandboxTemplate` carrying
+  the full pod spec, SA, Secret, PVC, env (ADR-0003), `runtimeClassName` unset
+  (runc), `envVarsInjectionPolicy: Allowed`.
+- ApplicationSet emits a per-tenant `SandboxTemplate` + `SandboxClaim`.
+- Repoint the per-tenant `HTTPRoute` backend to the Sandbox headless Service;
+  remove the KEDA `HTTPScaledObject`; `operatingMode: Running` (ADR-0004).
+- **Verify:** claim → Sandbox Ready → OpenClaw reachable via existing path →
+  Bedrock call succeeds via Pod Identity. Risk is confined to the lifecycle
+  model; runtime stays runc.
+
+### PR #1.5 — Scale-to-zero redesign (gated)
+- Resolve the wake mechanism and path→header strategy (ADR-0004 open items),
+  each in its own ADR.
+- Adopt sandbox-router, hibernation, heartbeat keepalive for the
+  background-work hazard (an agent doing inbound-traffic-free work must not be
+  hibernated mid-task).
+- **Verify:** idle → hibernate → reconnect → state preserved.
+
+### PR #2 — gVisor runtime tier
+- `gvisor` `RuntimeClass`; a gVisor-capable **ARM64** Karpenter NodePool
+  (AL2023 + `runsc` shim via user-data — the ai-on-eks reference NodePool is
+  x86 and must be adapted to ARM64).
+- Flip the per-tenant template's `runtimeClassName` to `gvisor` via a Helm value
+  (ADR-0003 makes this a one-field change).
+- **Sequencing constraint:** the gVisor NodePool must exist before any claim
+  schedules a gVisor pod, or scheduling fails.
+
+### Out of scope (future)
+- FQDN egress enforcement (Cilium `toFQDNs` on Standard EKS, or native
+  `ApplicationNetworkPolicy` on EKS Auto Mode). Auto Mode does not support
+  gVisor, so the two are mutually exclusive — a CNI decision deferred until
+  there is a concrete requirement.
+
+## Consequences
+
+**Positive**
+- Each PR has a single, focused risk surface and a clear deploy-verification
+  bar.
+- gVisor on ARM64 is verified feasible, so the all-Graviton cluster needs no x86
+  migration.
+
+**Negative**
+- The full value proposition (kernel isolation + scale-to-zero) is only complete
+  after PR #2 and PR #1.5 respectively; interim states are explicitly partial
+  (always-on after PR #1; runc-only until PR #2).
+
+## References
+
+- [docs/agent-sandbox.md](../agent-sandbox.md)
+- gVisor ARM64 compatibility: https://gvisor.dev/docs/user_guide/compatibility/linux/arm64/

--- a/docs/adr/0006-scale-to-zero-strategy.md
+++ b/docs/adr/0006-scale-to-zero-strategy.md
@@ -1,0 +1,82 @@
+# ADR-0006: Scale-to-zero strategy — adopt upstream KEP-968 (sandbox-gateway); ship always-on in PR #1
+
+- **Status:** Accepted
+- **Date:** 2026-06-19
+- **Deciders:** HC Lo (hclo)
+- **Depends on:** [ADR-0001](0001-adopt-agent-sandbox-model.md), [ADR-0004](0004-defer-hibernation-and-router.md), [ADR-0005](0005-phased-delivery.md)
+
+## Context
+
+ADR-0004 left an open item: how to achieve idle→0 + wake-on-traffic on the
+Sandbox model. Two things were then verified from source and upstream.
+
+**1. Suspend = pod termination, with no built-in idle/wake (verified from controller source).**
+In both v0.4.5 (`Spec.Replicas==0`) and v1beta1 (`operatingMode: Suspended`) the
+controller **deletes the pod**; there is no idle detection and no
+connection-triggered resume in the controller. So the Sandbox model alone does
+**not** replace KEDA's two active roles (idle-detect + request-holding activator).
+
+**2. Upstream is actively building exactly this — KEP-968.**
+[KEP-968 "Intelligent Auto-Suspend and Resume"](https://github.com/kubernetes-sigs/agent-sandbox/pull/972)
+(by janetkuo; a competing OpenClaw-named variant is [#970](https://github.com/kubernetes-sigs/agent-sandbox/pull/970)) introduces:
+- `AutoSuspendPolicy` in the **v1beta1** `SandboxSpec` (idle-detection strategies, scheduled wakeup);
+- a centralized Go **`sandbox-gateway`** that **buffers** an incoming request, patches
+  `operatingMode=Running`, waits for the resumed pod's HTTP **registration ping**,
+  then **flushes the buffered request** — transparent wake with zero dropped
+  connections. This covers the **browser / web-UI access pattern** directly (no
+  SDK-explicit-resume required), which was our exact open concern;
+- `SandboxWarmPool` integration for sub-second thaw.
+
+Our multi-tenant OpenClaw/Hermes use case is literally KEP-968's motivating
+"Claw-like" scenario.
+
+**3. Release status (verified).** Latest stable release is **v0.4.6** (v1alpha1);
+**v0.5.0rc1** is a prerelease; `AutoSuspendPolicy` is an **unmerged KEP, not in any
+release**. Therefore scale-to-zero with transparent wake **cannot be built on a
+stable API today**.
+
+## Decision
+
+- **PR #1 ships always-on** (`Running`) on the **v0.4.x stable line** (stay on the
+  validated v0.4.5; v0.4.6 is available), v1alpha1, direct `sandboxTemplateRef`
+  (ADR-0002/0003). KEDA `HTTPScaledObject` is removed.
+- **Scale-to-zero is deferred and will adopt the upstream KEP-968 path**
+  (`sandbox-gateway` + `AutoSuspendPolicy`) once it lands in a stable v1beta1
+  release. We will **not** build a throwaway activator.
+- If scale-to-zero is required before KEP-968 ships, build a **minimal interim
+  gateway that mirrors the KEP buffer-and-resume contract** (forward-compatible,
+  replaceable) — not KEDA-on-Sandbox.
+- The v1alpha1→v1beta1 migration (`sandboxTemplateRef`→`warmPoolRef` +
+  `AutoSuspendPolicy`) is an accepted future cost; it cannot be pre-empted because
+  the target API is unreleased.
+
+## Options considered
+
+- **KEDA on Sandbox:** rejected — a Sandbox exposes no `/scale` subresource for
+  KEDA to target, KEDA's interceptor cannot drive `operatingMode`, and it
+  contradicts adopting the Sandbox model.
+- **Custom throwaway activator now:** rejected — duplicates KEP-968.
+- **Adopt upstream KEP-968 when released (chosen)**, with an optional
+  forward-compatible interim gateway if scale-to-zero is needed sooner.
+
+## Consequences
+
+**Positive**
+- Aligned with the upstream direction; our use case is KEP-968's exact target.
+- PR #1 is unblocked and ships on a stable API.
+- High-leverage field contribution: comment on KEP-968 (#972/#970) with our
+  multi-tenant + web-UI transparent-wake + gVisor requirements; register on
+  [#776](https://github.com/kubernetes-sigs/agent-sandbox/issues/776).
+
+**Negative / interim**
+- No scale-to-zero until KEP-968 ships (or we build the interim gateway).
+  Interim posture is always-on; bound abandoned workspaces with `shutdownTime`/TTL
+  if cost requires.
+- A future v1beta1 migration is required to use `AutoSuspendPolicy`.
+
+## References
+
+- KEP-968: https://github.com/kubernetes-sigs/agent-sandbox/pull/972 (+ #970)
+- Roadmap (Auto Suspend/Resume, Scale to Zero, 1st Class Router — all Planned):
+  `https://github.com/kubernetes-sigs/agent-sandbox/blob/main/roadmap.md`
+- Controller suspend=delete evidence — see [ADR-0004](0004-defer-hibernation-and-router.md) Resolution.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records
+
+This directory records the significant architecture decisions for the
+multi-tenant OpenClaw platform sample, using a lightweight
+[MADR](https://adr.github.io/madr/)-style format.
+
+Each ADR is immutable once `Accepted`. To change a decision, add a new ADR
+that supersedes the old one (note it in both records).
+
+## Status legend
+
+- **Proposed** — under discussion, not yet agreed.
+- **Accepted** — agreed and in force.
+- **Superseded by ADR-NNNN** — replaced by a later decision.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-adopt-agent-sandbox-model.md) | Adopt the agent-sandbox model for tenant workspace isolation | Accepted |
+| [0002](0002-pin-agent-sandbox-v0.4.5.md) | Pin agent-sandbox v0.4.5 (`v1alpha1`) and use the direct `sandboxTemplateRef` chain | Accepted |
+| [0003](0003-per-tenant-sandboxtemplate.md) | Render a per-tenant SandboxTemplate to carry ServiceAccount, Secret, PVC, and env | Accepted |
+| [0004](0004-defer-hibernation-and-router.md) | Defer hibernation + sandbox-router; PR #1 keeps path-based routing and `operatingMode: Running` | Accepted |
+| [0005](0005-phased-delivery.md) | Phased delivery: lifecycle → router/hibernation → gVisor | Accepted |
+| [0006](0006-scale-to-zero-strategy.md) | Scale-to-zero strategy: adopt upstream KEP-968 (sandbox-gateway); always-on in PR #1 | Accepted |
+
+> 0001 is the foundation and the format template. 0006 supplements 0002/0004/0005
+> with the verified KEP-968 / release-status findings (2026-06-19).

--- a/docs/agent-sandbox.md
+++ b/docs/agent-sandbox.md
@@ -1,0 +1,100 @@
+# Agent Sandbox Integration
+
+> Status: **design / in progress** (issue [#365](https://github.com/snese/sample-openclaw-multi-tenant-platform/issues/365))
+> Tracks adoption of the [kubernetes-sigs/agent-sandbox](https://agent-sandbox.sigs.k8s.io/) model, as packaged by [awslabs/ai-on-eks](https://awslabs.github.io/ai-on-eks/docs/infra/agents/agent-sandbox).
+
+## Why
+
+Today each tenant workspace is a plain `Deployment` isolated only at the namespace + `NetworkPolicy` level. Model-generated code therefore runs with the full host-kernel syscall surface. This document describes adopting the `Sandbox` Custom Resource model to gain:
+
+- A declarative, lifecycle-managed primitive purpose-built for "a long-running, stateful, singleton container with a stable identity" — which is exactly the per-tenant persistent OpenClaw workspace model.
+- A kernel isolation tier (gVisor `runsc`) selectable per workload, delivered as a `SandboxTemplate` field rather than a bespoke runtime layer.
+- Built-in hibernation + automatic resume on incoming connections, which replaces the per-tenant KEDA HTTP scale-to-zero for the agent tier.
+
+Positioning note: this uses AWS-native + OSS SIG primitives. It deliberately does **not** adopt the NVIDIA OpenShell / NemoClaw stack — OpenShell's headline value (inference-layer credential injection so the agent never sees the API key) is already provided here by Amazon Bedrock + EKS Pod Identity (zero API keys), and NemoClaw is an alpha, host-centric project that would need adapting into a sidecar/DaemonSet.
+
+## Current state (baseline)
+
+| Concern | Today |
+|---|---|
+| Provisioning | ArgoCD `ApplicationSet`; PostConfirmation Lambda appends a tenant element via the K8s API; one `Application` per tenant syncs `helm/charts/openclaw-platform` |
+| Workload | per-tenant `Deployment` (+ Service, HTTPRoute, NetworkPolicy, PVC, ServiceAccount) |
+| Isolation | namespace + `NetworkPolicy` (soft); no `runtimeClassName` |
+| Scale-to-zero | KEDA HTTP Add-on `HTTPScaledObject`, `scaleTargetRef.kind: Deployment`, min 0 / max 1 on request rate (idle 900s) |
+| Nodes | Graviton ARM64 (`t4g`, AL2023_ARM_64); Karpenter NodePool pinned to `arch: arm64` |
+| CNI | default VPC CNI (no Cilium) |
+
+## Target architecture
+
+```
+ArgoCD ApplicationSet (per tenant)
+  └── SandboxClaim  ──►  SandboxTemplate (runc | gvisor)
+                          └── Sandbox (singleton pod, stable identity, PVC-backed)
+                                ├── hibernate on idle  /  resume on incoming connection
+                                └── runtimeClassName selects isolation tier
+```
+
+The agent-sandbox controller (`agent-sandbox-system`) reconciles `Sandbox` / `SandboxClaim` / `SandboxTemplate`. The gVisor tier is a `SandboxTemplate` with `runtimeClassName: gvisor`, scheduled onto a gVisor-capable Karpenter NodePool.
+
+## Key design decisions
+
+### KEDA → native hibernation (agent tier)
+
+The `Sandbox` resource is a **singleton** and exposes no `/scale` subresource, so KEDA HTTP cannot target it — and does not need to. The agent-sandbox controller provides native scale-to-zero via **hibernation** (pause on idle) + **automatic resume on incoming network connections**, with state preserved on a PVC. For the agent tier we therefore remove the per-tenant `HTTPScaledObject` and rely on the controller. KEDA may still be used for any platform routing/proxy `Deployment` tier (different layer, no conflict).
+
+### Background-work hazard (must mitigate)
+
+Hibernation resumes on **incoming** connections only. A tenant agent doing background work with no inbound traffic for the idle window risks being hibernated mid-task. Mitigations:
+
+- a lightweight **heartbeat** keepalive so active background work maintains recent incoming activity, and/or
+- `shutdownTime` / TTL reset around known long-running windows, and
+- PVC-backed state so durable work survives hibernate/resume.
+
+Note: snapshot-based suspend/resume is GKE-specific and **not** available on EKS Standard; on EKS we rely on hibernation-via-network-activity + PVC.
+
+### gVisor on ARM64
+
+gVisor supports ARM64 ("generally supported with exceptions"), so the all-Graviton cluster needs no x86 migration. The gVisor tier requires a Karpenter NodePool whose AL2023 nodes install the `runsc` containerd shim via user-data; the ai-on-eks reference NodePool is x86, so its user-data must be adapted to ARM64.
+
+## Phased delivery
+
+### PR #1 — Sandbox control plane + tenant migration (runc)
+
+1. Install the agent-sandbox controller + CRDs (`scripts/setup-agent-sandbox.sh`, wired into `deploy-all.sh`). _(this PR, additive)_
+2. Add a `runc` `SandboxTemplate`.
+3. Migrate the per-tenant workload from `Deployment` to `SandboxClaim`.
+4. Remove the agent-tier KEDA `HTTPScaledObject`; rely on controller hibernation.
+5. Add the heartbeat keepalive.
+
+Runtime stays `runc` so the lifecycle-model change is isolated from the runtime change.
+
+### PR #2 — gVisor runtime tier
+
+1. `gvisor` `RuntimeClass`.
+2. gVisor-capable ARM64 Karpenter NodePool (AL2023 + `runsc` shim via user-data).
+3. `gvisor` `SandboxTemplate`.
+4. Flip the tenant claim to the gVisor template (a single field).
+
+Sequencing constraint: the gVisor NodePool must exist before a `SandboxClaim` references the gVisor template, or the pod cannot schedule.
+
+### Out of scope (future)
+
+FQDN egress enforcement (Cilium `toFQDNs` on Standard EKS, or native `ApplicationNetworkPolicy` `domainNames` on EKS Auto Mode). Requires a CNI decision; Auto Mode does not support gVisor, so the two are mutually exclusive.
+
+## Verification plan
+
+| Layer | How |
+|---|---|
+| Static | `make lint` (cdk synth, helm lint, shellcheck) + `make test` (jest, lambda) — no cluster |
+| Controller | `setup-agent-sandbox.sh` then `kubectl -n agent-sandbox-system get pods` |
+| runc claim | apply a `SandboxClaim`, assert the Sandbox pod reaches Ready, exec a Bedrock call |
+| Hibernation | leave idle past the window, assert pod scales to 0, then resume on connection and assert state preserved |
+| gVisor (PR #2) | assert pod `runtimeClassName=gvisor`, schedule onto the gVisor NodePool, run the Bedrock conformance check |
+
+A live cluster (EKS, or a local kind/k3d for the runc control-plane checks) is required for everything below the static row.
+
+## References
+
+- [Agent Sandbox docs](https://agent-sandbox.sigs.k8s.io/docs/) (overview, lifecycle, installation)
+- [awslabs/ai-on-eks — Agent Sandbox on EKS](https://awslabs.github.io/ai-on-eks/docs/infra/agents/agent-sandbox)
+- [gVisor ARM64 compatibility](https://gvisor.dev/docs/user_guide/compatibility/linux/arm64/)

--- a/helm/agent-sandbox-template-runc.yaml
+++ b/helm/agent-sandbox-template-runc.yaml
@@ -1,0 +1,73 @@
+# Platform-level SandboxTemplate for the `runc` (default) isolation tier.
+#
+# One reusable template per runtime tier (see docs/agent-sandbox.md). Per-tenant
+# specifics (ServiceAccount for Pod Identity, EFS PVC, config/secret volumes,
+# env) are layered on at claim time via the per-tenant SandboxClaim, not here.
+#
+# The gVisor tier (PR #2) is an identical template plus
+# `spec.podTemplate.spec.runtimeClassName: gvisor` and the gVisor NodePool
+# toleration — gVisor is delivered THROUGH this field, not as a separate layer.
+#
+# Schema validated with: kubectl apply --dry-run=server (against the installed
+# extensions.agents.x-k8s.io CRD, v0.4.5).
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: openclaw-runc
+  labels:
+    app.kubernetes.io/part-of: openclaw-platform
+    openclaw.io/runtime-tier: runc
+spec:
+  # runc tier: no runtimeClassName (default runtime). PR #2 adds an
+  # openclaw-gvisor template that sets runtimeClassName: gvisor.
+  podTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openclaw
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: main
+          image: ghcr.io/openclaw/openclaw
+          command: ["node", "dist/index.js"]
+          args: ["gateway", "--port", "18789", "--bind", "lan"]
+          ports:
+            - containerPort: 18789
+              protocol: TCP
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          readinessProbe:
+            tcpSocket:
+              port: 18789
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 18789
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          startupProbe:
+            tcpSocket:
+              port: 18789
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+      restartPolicy: OnFailure

--- a/helm/applicationset.yaml
+++ b/helm/applicationset.yaml
@@ -48,9 +48,11 @@ spec:
             skills:
               - weather
               - gog
-            scaleToZero:
+            sandbox:
               enabled: true
-              minReplicas: 0
+              runtimeClassName: ""   # runc (PR#1, ADR-0005); PR#2 sets "gvisor"
+            scaleToZero:
+              enabled: false   # superseded by Sandbox model (ADR-0004/0006); always-on in PR#1, scale-to-zero returns via upstream KEP-968
             ingress:
               host: "DOMAIN"
             gateway:

--- a/helm/charts/openclaw-platform/templates/hpa.yaml
+++ b/helm/charts/openclaw-platform/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (not .Values.sandbox.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/openclaw-platform/templates/httproute.yaml
+++ b/helm/charts/openclaw-platform/templates/httproute.yaml
@@ -19,7 +19,7 @@ spec:
             type: PathPrefix
             value: /t/{{ .Values.tenant.name }}
       backendRefs:
-        {{- if .Values.scaleToZero.enabled }}
+        {{- if and .Values.scaleToZero.enabled (not .Values.sandbox.enabled) }}
         # Route through KEDA interceptor for scale-from-zero.
         # Interceptor counts requests, scales backend, then proxies.
         # Requires ReferenceGrant in keda namespace (created by Helm chart).
@@ -27,6 +27,9 @@ spec:
           namespace: keda
           port: 8080
         {{- else }}
+        # Direct to the tenant Service. When sandbox.enabled, this Service selects
+        # the Sandbox pod by label (ADR-0004: PR#1 keeps path-based routing,
+        # always-on, no KEDA).
         - name: {{ include "openclaw-helm.fullname" . }}
           port: {{ .Values.service.port }}
         {{- end }}

--- a/helm/charts/openclaw-platform/templates/httpscaledobject.yaml
+++ b/helm/charts/openclaw-platform/templates/httpscaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scaleToZero.enabled }}
+{{- if and .Values.scaleToZero.enabled (not .Values.sandbox.enabled) }}
 apiVersion: http.keda.sh/v1alpha1
 kind: HTTPScaledObject
 metadata:

--- a/helm/charts/openclaw-platform/templates/referencegrant.yaml
+++ b/helm/charts/openclaw-platform/templates/referencegrant.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scaleToZero.enabled }}
+{{- if and .Values.scaleToZero.enabled (not .Values.sandbox.enabled) }}
 # ReferenceGrant allows this tenant's HTTPRoute to reference the KEDA
 # interceptor Service in the keda namespace (cross-namespace backendRef).
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/helm/charts/openclaw-platform/templates/sandboxclaim.yaml
+++ b/helm/charts/openclaw-platform/templates/sandboxclaim.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.sandbox.enabled }}
+# Per-tenant SandboxClaim (ADR-0001 / ADR-0002).
+#
+# v0.4.x / v1alpha1: the claim references the SandboxTemplate DIRECTLY via
+# sandboxTemplateRef (verified from the v0.4.5 CRD). No WarmPool required on the
+# cold-start path. PR#1 is always-on (no lifecycle.shutdownTime); scale-to-zero
+# is deferred to the upstream KEP-968 path (ADR-0006).
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: {{ include "openclaw-helm.fullname" . }}
+  labels:
+    {{- include "openclaw-helm.labels" . | nindent 4 }}
+spec:
+  sandboxTemplateRef:
+    name: {{ include "openclaw-helm.fullname" . }}
+{{- end }}

--- a/helm/charts/openclaw-platform/templates/sandboxtemplate.yaml
+++ b/helm/charts/openclaw-platform/templates/sandboxtemplate.yaml
@@ -1,16 +1,26 @@
-{{- if not .Values.sandbox.enabled }}
-apiVersion: apps/v1
-kind: Deployment
+{{- if .Values.sandbox.enabled }}
+# Per-tenant SandboxTemplate (ADR-0001 / ADR-0003).
+#
+# Rendered PER TENANT by the ArgoCD ApplicationSet so it can carry the
+# per-tenant ServiceAccount (Pod Identity), gateway-token Secret, downward-API
+# env, and PVC — none of which fit in the v1alpha1 SandboxClaim.env (plain
+# name/value only). The SandboxClaim references this template by name.
+#
+# Runtime tier (ADR-0005): .Values.sandbox.runtimeClassName empty => runc (PR#1);
+# "gvisor" => PR#2 (a one-value change, scheduled onto the gVisor NodePool).
+#
+# Schema: extensions.agents.x-k8s.io/v1alpha1 (pinned v0.4.x, ADR-0002).
+# envVarsInjectionPolicy default is Disallowed; set Allowed so the per-tenant
+# SandboxClaim may inject env (ADR-0003).
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
 metadata:
   name: {{ include "openclaw-helm.fullname" . }}
   labels:
     {{- include "openclaw-helm.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicas }}
-  selector:
-    matchLabels:
-      {{- include "openclaw-helm.selectorLabels" . | nindent 6 }}
-  template:
+  envVarsInjectionPolicy: Allowed
+  podTemplate:
     metadata:
       labels:
         {{- include "openclaw-helm.selectorLabels" . | nindent 8 }}
@@ -21,6 +31,9 @@ spec:
         instrumentation.opentelemetry.io/inject-dotnet: "false"
     spec:
       serviceAccountName: {{ include "openclaw-helm.fullname" . }}
+      {{- if .Values.sandbox.runtimeClassName }}
+      runtimeClassName: {{ .Values.sandbox.runtimeClassName }}
+      {{- end }}
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
@@ -55,7 +68,7 @@ spec:
           mountPath: /home/node/.openclaw
         - name: tmp
           mountPath: /tmp
-      
+
       - name: init-skills
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         securityContext:
@@ -113,10 +126,6 @@ spec:
             if [ ! -f /home/node/.openclaw/workspace/node_modules/@aws-sdk/client-secrets-manager/dist-cjs/index.js ]; then
               cd /home/node/.openclaw/workspace && npm install --no-save @aws-sdk/client-secrets-manager 2>/dev/null
             fi
-            # Patch @smithy/credential-provider-imds: add EKS Pod Identity Agent IP (169.254.170.23)
-            # to GREENGRASS_HOSTS. Without this, fromContainerMetadata rejects the Pod Identity endpoint.
-            # Only patch workspace copy (writable PVC). /app is read-only (image layer) and cannot be
-            # modified with readOnlyRootFilesystem.
             IMDS_FILE=/home/node/.openclaw/workspace/node_modules/@smithy/credential-provider-imds/dist-cjs/index.js
             if [ -f "$IMDS_FILE" ] && ! grep -q "169.254.170.23" "$IMDS_FILE"; then
               sed -i 's/"127.0.0.1": true,/"127.0.0.1": true, "169.254.170.23": true,/' "$IMDS_FILE"
@@ -130,7 +139,7 @@ spec:
           mountPath: /home/node/.openclaw
         - name: tmp
           mountPath: /tmp
-      
+
       containers:
       - name: main
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -203,7 +212,7 @@ spec:
         - name: bash-aliases
           mountPath: /home/node/.bash_aliases
           subPath: bash_aliases
-      
+
       volumes:
       - name: config
         configMap:

--- a/helm/charts/openclaw-platform/templates/service.yaml
+++ b/helm/charts/openclaw-platform/templates/service.yaml
@@ -1,3 +1,9 @@
+{{- if not .Values.sandbox.enabled }}
+# In sandbox mode the agent-sandbox controller creates its own headless Service
+# named after the Sandbox (= fullname), so we must NOT create a conflicting
+# ClusterIP Service here (the controller cannot adopt a non-headless Service —
+# ClusterIP is immutable). The HTTPRoute backendRef (= fullname) resolves to the
+# controller-created Service. (Found via deploy-verify, ADR-0004.)
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +19,4 @@ spec:
       name: gateway
   selector:
     {{- include "openclaw-helm.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/charts/openclaw-platform/values.yaml
+++ b/helm/charts/openclaw-platform/values.yaml
@@ -68,6 +68,13 @@ scaleToZero:
   minReplicas: 0
   maxReplicas: 1
 
+# Sandbox model (ADR-0001/0003/0005). When enabled, the tenant workload is a
+# per-tenant SandboxTemplate + SandboxClaim instead of a Deployment.
+# runtimeClassName: "" = runc (PR#1); "gvisor" = kernel isolation (PR#2).
+sandbox:
+  enabled: false
+  runtimeClassName: ""
+
 config:
   gateway:
     port: 18789

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -105,6 +105,13 @@ echo "==> Step 4/6: Installing KEDA"
 bash "$SCRIPTS_DIR/setup-keda.sh"
 echo ""
 
+# ── Step 4b: Agent Sandbox controller + CRDs (ADR-0001) ─────────────────────
+# Required for the Sandbox model (SandboxTemplate/SandboxClaim) the chart emits
+# when sandbox.enabled=true. CRDs must exist before ArgoCD syncs tenant claims.
+echo "==> Step 4b: Installing agent-sandbox controller + CRDs"
+bash "$SCRIPTS_DIR/setup-agent-sandbox.sh"
+echo ""
+
 # ── Step 5: Post-deploy (CloudFront ALB + Route53) ──────────────────────────
 echo "==> Step 5/6: Post-deploy setup"
 

--- a/scripts/setup-agent-sandbox.sh
+++ b/scripts/setup-agent-sandbox.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Install the kubernetes-sigs/agent-sandbox controller + CRDs.
+#
+# Adopts the agent-sandbox model (Sandbox / SandboxClaim / SandboxTemplate /
+# SandboxWarmPool) used by awslabs/ai-on-eks. This script installs only the
+# control plane (controller + CRDs); SandboxTemplates and per-tenant
+# SandboxClaims are applied separately (see docs/agent-sandbox.md).
+#
+# Install commands follow the official guide:
+#   https://agent-sandbox.sigs.k8s.io/docs/getting_started/install_prerequisites/
+#
+# Usage:
+#   bash scripts/setup-agent-sandbox.sh            # install pinned version
+#   bash scripts/setup-agent-sandbox.sh --dry-run  # print actions only
+#   AGENT_SANDBOX_VERSION=latest bash scripts/setup-agent-sandbox.sh
+set -euo pipefail
+
+source "$(dirname "$0")/lib/common.sh"
+require_cluster
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+# Pin by default for reproducible deploys; matches the ai-on-eks default.
+# Set AGENT_SANDBOX_VERSION=latest to resolve the newest release at install time.
+AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.4.5}"
+
+run() {
+  echo "  → $*"
+  $DRY_RUN || "$@"
+}
+
+echo "==> Installing agent-sandbox controller + CRDs"
+
+if [[ "$AGENT_SANDBOX_VERSION" == "latest" ]]; then
+  echo "  Resolving latest release tag from GitHub"
+  if ! $DRY_RUN; then
+    AGENT_SANDBOX_VERSION=$(curl -fsSL https://api.github.com/repos/kubernetes-sigs/agent-sandbox/releases/latest | jq -r '.tag_name')
+  fi
+fi
+echo "  Version: ${AGENT_SANDBOX_VERSION}"
+
+BASE_URL="https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}"
+
+echo "  Step 1: Core components (controller + Sandbox CRD)"
+run kubectl apply -f "${BASE_URL}/manifest.yaml"
+
+echo "  Step 2: Extension CRDs (SandboxTemplate / SandboxClaim / SandboxWarmPool)"
+run kubectl apply -f "${BASE_URL}/extensions.yaml"
+
+echo "  Step 3: Wait for controller to be ready"
+if ! $DRY_RUN; then
+  kubectl -n agent-sandbox-system rollout status deploy --timeout=120s 2>/dev/null || true
+  kubectl -n agent-sandbox-system get pods
+fi
+
+echo ""
+echo "=== agent-sandbox installed (${AGENT_SANDBOX_VERSION}) ==="
+echo "  Controller namespace: agent-sandbox-system"
+echo "  Next: apply a SandboxTemplate, then migrate tenants to SandboxClaim."
+echo "  See docs/agent-sandbox.md"
+echo "================================================"


### PR DESCRIPTION
## Summary
PR #1 of the agent-sandbox adoption tracked in #5. Migrates each tenant
workspace from a plain Deployment to the agent-sandbox SandboxClaim →
SandboxTemplate → Sandbox model (runtime stays runc) and installs the
controller + CRDs as an ArgoCD-managed addon. Every tenant gets a declarative,
lifecycle-managed, kernel-isolatable workspace with a stable identity and
PVC-backed state. The gVisor runtime tier is a follow-up (PR #2).

## What's in this PR
- `scripts/setup-agent-sandbox.sh` (wired into `deploy-all.sh`) — installs
  controller + CRDs, additive
- Per-tenant `runc` SandboxTemplate — full pod spec ported from the tenant
  Deployment (3 initContainers incl. the Pod Identity IMDS patch, config/skills/
  tools, configMap + PVC + tmp volumes, serviceAccount, env),
  `envVarsInjectionPolicy: Allowed`, `runtimeClassName` driven by a value
- Per-tenant SandboxClaim (direct `sandboxTemplateRef`)
- Gateway HTTPRoute backend points at the tenant Service (sandbox mode); tenant
  Service gated off so the controller owns the headless Service
- Removes the agent-tier KEDA HTTPScaledObject / HPA / ReferenceGrant /
  Deployment (gated behind `sandbox.*` values); ApplicationSet flipped to
  sandbox mode
- 6 ADRs (`docs/adr/0001-0006`) + design doc (`docs/agent-sandbox.md`)

## What's deferred (and why)
- **Scale-to-zero / hibernation → PR #1.5.** On the pinned v0.4.5 (v1alpha1),
  `Replicas==0` deletes the pod and there is no connection-triggered resume
  (that lands in v1beta1). This PR runs always-on; scale-to-zero is gated on
  upstream Auto Suspend/Resume (kubernetes-sigs/agent-sandbox#968) plus a
  data-path router. See ADR-0004 / ADR-0006.
- **gVisor tier → PR #2.**

## Verification (live EKS cluster, us-east-1)
- Static: `helm template` + `helm lint` pass in both legacy and sandbox modes.
- Control plane: agent-sandbox v0.4.5 controller + CRDs deployed and reconciling.
- Lifecycle (server-side dry-run + real apply): controller reconciled
  SandboxClaim → SandboxTemplate → Sandbox; pod scheduled, EFS PVC (RWX) bound,
  all 3 initContainers completed, the workspace gateway started.
- Caught a lint-invisible bug: the controller creates a same-named headless
  Service that collided with the chart's ClusterIP Service (ClusterIP is
  immutable → cannot adopt). Fixed by gating the chart Service off in sandbox
  mode.
- A bare test claim CrashLooped only because it lacked a Pod Identity
  association and gateway-token secret (tenant provisioning, done by the
  PostConfirmation Lambda for real tenants), not a manifest defect.

## Part of #5
Implements the PR #1 checkbox. PR #2 (gVisor) and PR #1.5 (router + hibernation)
follow.
