### PR TITLE
fix: unblock fresh deploys (AWS CDK CLI pin + auth-ui asset upload)

### DIFF
--- a/cdk/lib/eks-cluster-stack.ts
+++ b/cdk/lib/eks-cluster-stack.ts
@@ -1035,7 +1035,24 @@ function handler(event) {
 
     new s3deploy.BucketDeployment(this, 'AuthUiDeployment', {
       sources: [
-        s3deploy.Source.asset('../auth-ui'),
+        // Ship only the static runtime files. The auth-ui is vanilla JS with no
+        // build step; node_modules holds dev-only deps (jest/eslint/puppeteer,
+        // ~110MB) that are never served. Uploading them flooded the deployment
+        // Lambda (thousands of small files) and exceeded its timeout, blocking
+        // CREATE_COMPLETE. Excluding them drops the upload to ~265KB / 7 files.
+        s3deploy.Source.asset('../auth-ui', {
+          exclude: [
+            'node_modules',
+            'node_modules/**',
+            'tests',
+            'tests/**',
+            'package.json',
+            'package-lock.json',
+            '.git',
+            '.gitignore',
+            '**/.DS_Store',
+          ],
+        }),
       ],
       destinationBucket: authUiBucket,
       distribution,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/jest": "30.0.0",
         "@types/node": "24.12.0",
-        "aws-cdk": "2.1114.1",
+        "aws-cdk": "^2.1128.1",
         "cdk-nag": "2.37.55",
         "jest": "30.3.0",
         "ts-jest": "29.4.6",
@@ -1686,9 +1686,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1114.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1114.1.tgz",
-      "integrity": "sha512-jMaKPWQQs1G6AbhfCQG2zGrgAhTxzP0jn4T2CuwONuvcV374dMPhfC/LBAv48ruSOgpCK9x6V1xeO/aH3EchAA==",
+      "version": "2.1128.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1128.1.tgz",
+      "integrity": "sha512-y9OHn5/BOcIiq409vPvpypMIr7/8M1ScFe8IkFMSCN1/GI/5c73fQ4pfzNq+VDkj86T5zxs7BQ1qU2lQQytdXA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "30.0.0",
     "@types/node": "24.12.0",
-    "aws-cdk": "2.1114.1",
+    "aws-cdk": "^2.1128.1",
     "cdk-nag": "2.37.55",
     "jest": "30.3.0",
     "ts-jest": "29.4.6",


### PR DESCRIPTION
## What
Two independent fixes that currently block every fresh `cdk deploy` of this
sample, cherry-picked out of #9 so main is deployable without waiting for the
gVisor feature review. Part of #5 hygiene.

- **fix(deps):** bump the AWS CDK CLI to `^2.1128.1`. A dependabot bump took
  `aws-cdk-lib` to 2.260.0 (cloud-assembly schema 54), which the pinned CLI
  2.1114.1 cannot read — `cdk synth`/`deploy` fail on a clean checkout.
- **fix(auth-ui):** exclude `node_modules`/`tests` from the AuthUi
  `BucketDeployment`. The asset upload was ~110 MB / 10,790 files and timed out
  the AWS Lambda function backing the deployment, blocking `CREATE_COMPLETE`
  for all fresh deploys. Now ~52 KB / 7 files.

## Verification
Both fixes were verified as part of the fresh full-stack `cdk deploy`
documented in #9 (stack reached CREATE_COMPLETE on a net-new deployment in
us-east-1). CI covers synth on every PR.

## Notes
#9 is rebased on top of these commits.