### PR TITLE
fix: package bin shadowed the AWS CDK CLI; sync ADR index, README, chart version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Deploy in ~30 minutes. Scale to 500 users. Pay only for what you use.
 
 - **One tenant per user** -- isolated namespace, PVC, network policy, IAM role
 - **Zero API keys** -- LLM access via Amazon Bedrock + Pod Identity
-- **Scale to zero** -- KEDA scales idle pods to 0; cold start in 15-30s
+- **Scale to zero** -- KEDA scales idle pods to 0; cold start in 15-30s.
+  *Applies to the default (Deployment) tenant mode. The opt-in agent-sandbox
+  mode currently runs always-on — native suspend/resume is tracked upstream
+  (kubernetes-sigs/agent-sandbox KEP-968; see [ADR-0006](docs/adr/0006-scale-to-zero-strategy.md)).*
 - **3-layer origin protection** -- internet-facing ALB with CF-only SG + AWS WAF + HTTPS
 - **Custom auth UI** -- branded login/signup on your domain (no Amazon Cognito Hosted UI)
 - **Self-service signup** -- Amazon Cognito + AWS Lambda auto-provisions tenants
@@ -140,6 +143,7 @@ Sign up at `https://<your-domain>/auth/` with an email matching your `allowedEma
 | Network | Internet-facing ALB with CF-only SG (pl-82a045eb) + AWS WAF + HTTPS |
 | Auth | Amazon Cognito signup + local token auth + 3-layer origin protection |
 | Tenant | Namespace isolation + NetworkPolicy (enforced via VPC CNI, see below) + ABAC |
+| Runtime | runc by default; opt-in gVisor kernel-isolation tier per tenant ([ADR-0007](docs/adr/0007-gvisor-runtime-tier.md)) |
 | Secrets | exec SecretRef -- fetched on-demand, never persisted |
 | LLM | Amazon Bedrock via Pod Identity -- zero API keys |
 | Cost | Per-tenant monthly budget with per-model pricing |

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,9 +1,6 @@
 {
   "name": "cdk",
   "version": "0.1.0",
-  "bin": {
-    "cdk": "bin/cdk.js"
-  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,8 @@ that supersedes the old one (note it in both records).
 | [0004](0004-defer-hibernation-and-router.md) | Defer hibernation + sandbox-router; PR #1 keeps path-based routing and `operatingMode: Running` | Accepted |
 | [0005](0005-phased-delivery.md) | Phased delivery: lifecycle → router/hibernation → gVisor | Accepted |
 | [0006](0006-scale-to-zero-strategy.md) | Scale-to-zero strategy: adopt upstream KEP-968 (sandbox-gateway); always-on in PR #1 | Accepted |
+| [0007](0007-gvisor-runtime-tier.md) | gVisor runtime tier — selectable kernel isolation + runtime tier extension contract | Accepted |
+| [0008](0008-enforce-network-policy-egress.md) | Enforce per-tenant egress control via Amazon VPC CNI NetworkPolicy | Accepted |
 
 > 0001 is the foundation and the format template. 0006 supplements 0002/0004/0005
 > with the verified KEP-968 / release-status findings (2026-06-19).

--- a/helm/charts/openclaw-platform/Chart.yaml
+++ b/helm/charts/openclaw-platform/Chart.yaml
@@ -4,5 +4,5 @@ description: |
   OpenClaw AI Agent Helm chart -- reference templates for documentation and manual debugging.
   Tenant provisioning is handled by ArgoCD ApplicationSet. Each tenant gets an ArgoCD Application that syncs this chart.
 type: application
-version: 1.3.14
+version: 1.4.0
 appVersion: "2026.4.9"


### PR DESCRIPTION
## What

**Bug fix:** `cdk/package.json` declared `"bin": {"cdk": "bin/cdk.js"}` on a package named `cdk`. After any local `tsc` run produces `bin/cdk.js` (gitignored), `npx cdk <cmd>` resolves to the CDK **app itself** instead of the aws-cdk CLI. The bare app receives no `CDK_CONTEXT_JSON`, so `cdk.json` values and `-c` flags silently vanish and every command fails with "Missing required CDK context values" — even though the config is correct. Fresh checkouts and CI never reproduce it (no compiled `.js` present), which makes it a confusing local-only failure. Removing the unused `bin` entry fixes `npx` resolution permanently.

**Docs/version sync** (post #9/#11):
- ADR index: add [0007](docs/adr/0007-gvisor-runtime-tier.md) and [0008](docs/adr/0008-enforce-network-policy-egress.md)
- README: scope the scale-to-zero claim honestly to the default Deployment mode (the agent-sandbox mode runs always-on pending upstream kubernetes-sigs/agent-sandbox KEP-968), and add the runtime-tier row to the Security table
- Chart.yaml: 1.3.14 → 1.4.0 (gVisor tier shipped in #9)

## Verification
- With a stale `bin/cdk.js` present, `npx cdk --version` previously crashed with the context error; after this fix it correctly reports the aws-cdk CLI version and `npx cdk synth` passes context validation from `cdk.json`.
- `helm lint` pass; `package.json` valid JSON.